### PR TITLE
Fixed the package name in the installation part. fixes #27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maestro-rust-sdk"
-version = "1.2.2"
+version = "1.2.3"
 description = "Rust SDK for the Maestro Dapp Platform"
 repository = "https://github.com/maestro-org/rust-sdk"
 documentation = "https://docs.gomaestro.org/"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 ```toml
 [dependencies]
-maestro = { git = "https://github.com/maestro-org/rust-sdk.git" }
+maestro-rust-sdk = { git = "https://github.com/maestro-org/rust-sdk.git" }
 ```
 
 ```rust


### PR DESCRIPTION
## Summary

### What

Changed the `maestro` package name to `maestro-rust-sdk`

### Why

Rust analyzer couldn't recognize the the repo as a package with the `maestro` as the package name.

### How
_

p.s. The main package name can alternatively be changed to `maestro` as well.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Code refactoring (improving code quality without changing its behavior)
- [] Documentation update (adding or updating documentation related to the project)

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's coding style and best practices
- [ ] My code is appropriately commented and includes relevant documentation
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass
- [x] I have updated the documentation, if necessary

## Testing

N/A

## Additional Information

 #N/A
